### PR TITLE
fix: Remove unused ConfigMap

### DIFF
--- a/deploy/templates/configmap.yaml
+++ b/deploy/templates/configmap.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "voiesbordelaises.fullname" . }}
-  labels:
-    {{- include "voiesbordelaises.labels" . | nindent 4 }}
-data:
-  NEXT_PUBLIC_MAPBOX_CENTER: "{{ .Values.mapbox.center }}"
-  NEXT_PUBLIC_MAPBOX_ZOOM: "{{ .Values.mapbox.zoom }}"


### PR DESCRIPTION
Mapbox config, erroneously copied over from the 'compteurs-velo' project