### PR TITLE
Update ligne-10.json

### DIFF
--- a/content/reve-bordelais/ligne-10.json
+++ b/content/reve-bordelais/ligne-10.json
@@ -112,7 +112,7 @@
                 "type": "inconnu",
                 "link": "/reve-10#les-tronçons-douest-en-est",
                 "quality": "satisfactory",
-                "doneAt": "01/03/2025"
+                "doneAt": "01/03/2020"
             }
         },
         {


### PR DESCRIPTION
L'aménagement Larminat-Juin a été livré au printemps 2020, il passe dans la catégorie "<2021"